### PR TITLE
Add support for TOTP login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 2024-01-25 v1.23.0
+
+- Based on Comet 23.12.4
+- Add TOTP login support
+
 ## 2024-01-23 v1.22.0
 
 - Based on Comet 23.12.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 2024-01-25 v1.23.0
+## Upcoming
 
 - Based on Comet 23.12.4
 - Add TOTP login support

--- a/cometsdk.go
+++ b/cometsdk.go
@@ -3909,13 +3909,29 @@ type WindowsCodeSignProperties struct {
 
 // CometAPIClient is the base struct for all request methods
 type CometAPIClient struct {
+	// ServerURL is used to specify server which api calls will be made to.
 	ServerURL string
-	Username  string
-	Password  string
-	// Optional: Specify this value if using PasswordTOTP based login.
+	// Username if specified will be used for api authentication using AuthType "Password" or if
+	// TOTPKey is also specified then AuthType "PasswordTOTP" will be used.
+	Username string
+	// Password if specified will be used for api authentication using AuthType "Password" or if
+	// TOTPKey is also specified then AuthType "PasswordTOTP" will be used.
+	Password string
+	// TOTPKey (optional) if specified will be used for api authentication using AuthType "PasswordTOTP".
+	// The TOTPKey once used is automatically cleared as it cannot be reused.
 	TOTPKey string
-	// Optional: Specify this value if using SessionKey
+	// SessionKey (optional) if specified will be used for api authentication using AuthType "SessionKey".
+	// This value when set takes precedence over other specified values.
+	// If ReuseSessionKey is set to true, this value is set automatically as part of any of the
+	// *SessionStart* api calls and used automatically for subsequent api authentications.
 	SessionKey string
+	// ReuseSessionKey (optional) when set to true, uses the SessionKey returned by the
+	// respective *SessionStart* api calls and automatically sets it on the CometAPIClient.
+	// Any subsequent api calls made on the CometAPIClient without clearing the SessionKey
+	// will result in the same SessionKey being used automatically for api authentication.
+	// ReuseSessionKey is especially useful when using TOTP based authentication, otherwise
+	// you need to enter a new TOTPKey for every api call.
+	ReuseSessionKey bool
 }
 
 // NewCometAPIClient constructs and returns an instance of CometAPIClient
@@ -4103,8 +4119,10 @@ func (c *CometAPIClient) AdminAccountSessionStart(SelfAddress *string) (*Session
 	if err != nil {
 		return nil, err
 	}
-	// Set the SessionKey so that future invocations use the SessionKey.
-	c.SessionKey = result.SessionKey
+	if c.ReuseSessionKey {
+		// Set the SessionKey so that future invocations use the SessionKey.
+		c.SessionKey = result.SessionKey
+	}
 
 	return result, nil
 }
@@ -4133,8 +4151,10 @@ func (c *CometAPIClient) AdminAccountSessionStartAsUser(TargetUser string) (*Ses
 	if err != nil {
 		return nil, err
 	}
-	// Set the SessionKey so that future invocations use the SessionKey.
-	c.SessionKey = result.SessionKey
+	if c.ReuseSessionKey {
+		// Set the SessionKey so that future invocations use the SessionKey.
+		c.SessionKey = result.SessionKey
+	}
 
 	return result, nil
 }
@@ -9091,8 +9111,11 @@ func (c *CometAPIClient) HybridSessionStart() (*SessionKeyRegeneratedResponse, e
 	if err != nil {
 		return nil, err
 	}
-	// Set the SessionKey so that future invocations use the SessionKey.
-	c.SessionKey = result.SessionKey
+	if c.ReuseSessionKey {
+		// Set the SessionKey so that future invocations use the SessionKey.
+		c.SessionKey = result.SessionKey
+	}
+
 	return result, nil
 }
 
@@ -10522,8 +10545,10 @@ func (c *CometAPIClient) UserWebSessionStart() (*SessionKeyRegeneratedResponse, 
 	if err != nil {
 		return nil, err
 	}
-	// Set the SessionKey so that future invocations use the SessionKey.
-	c.SessionKey = result.SessionKey
+	if c.ReuseSessionKey {
+		// Set the SessionKey so that future invocations use the SessionKey.
+		c.SessionKey = result.SessionKey
+	}
 
 	return result, nil
 }

--- a/examples/admin/main.go
+++ b/examples/admin/main.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	sdk "github.com/CometBackup/comet-go-sdk"
+	"github.com/CometBackup/comet-go-sdk/examples/util"
 )
 
 type Client struct {
@@ -79,11 +80,22 @@ func main() {
 	if (*list && *download != 0) || (!*list && *download == 0) {
 		log.Fatal("Error: A command must be chosen. Choose one of either '--list' or '--download #'")
 	}
-
+	if *username == "" || *password == "" {
+		var err error
+		*username, *password, err = util.Credentials()
+		if err != nil {
+			log.Fatal("Error getting username and password: ", err)
+		}
+	}
 	client, err := NewClient(*url, *username, *password)
 	if err != nil {
 		log.Fatal("Error creating client: ", err)
 	}
+	totp, err := util.Totp()
+	if err != nil {
+		log.Fatal("Error reading TOTP: ", err)
+	}
+	client.client.TOTPKey = totp
 
 	if *list {
 		err = client.ListAndPrintPlatforms()

--- a/examples/admin/main.go
+++ b/examples/admin/main.go
@@ -96,6 +96,9 @@ func main() {
 		log.Fatal("Error reading TOTP: ", err)
 	}
 	client.client.TOTPKey = totp
+	// ReuseSessionKey is especially useful when using TOTP based authentication, otherwise you need to enter a
+	// new TOTPKey for every api call.
+	client.client.ReuseSessionKey = true
 
 	if *list {
 		err = client.ListAndPrintPlatforms()

--- a/examples/util/credentials.go
+++ b/examples/util/credentials.go
@@ -1,0 +1,42 @@
+package util
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+
+	"golang.org/x/term"
+)
+
+func Credentials() (string, string, error) {
+	reader := bufio.NewReader(os.Stdin)
+
+	fmt.Print("Enter Username: ")
+	username, err := reader.ReadString('\n')
+	if err != nil {
+		return "", "", err
+	}
+	username = strings.TrimRight(username, "\r\n")
+	fmt.Print("Enter Password: ")
+	bytePassword, err := term.ReadPassword(int(syscall.Stdin))
+	if err != nil {
+		return "", "", err
+	}
+	fmt.Print("\n")
+	password := string(bytePassword)
+	return strings.TrimSpace(username), strings.TrimSpace(password), nil
+}
+
+func Totp() (string, error) {
+	reader := bufio.NewReader(os.Stdin)
+
+	fmt.Print("Enter TOTP: ")
+	totp, err := reader.ReadString('\n')
+	if err != nil {
+		return totp, err
+	}
+	totp = strings.TrimRight(totp, "\r\n")
+	return totp, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/CometBackup/comet-go-sdk
 
 go 1.17
+
+require golang.org/x/term v0.16.0
+
+require golang.org/x/sys v0.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
+golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.16.0 h1:m+B6fahuftsE9qjo0VWp2FW0mB3MTJvR0BaMQrq0pmE=
+golang.org/x/term v0.16.0/go.mod h1:yn7UURbUtPyrVJPGPq404EukNFxcm/foM+bV/bfcDsY=


### PR DESCRIPTION
Add optional TOTPKey and SessionKey in CometAPIClient. 
Users can now pass an optional TOTPKey if they wish to use TOTP based login for the API.
Once login is successful, the SessionKey is set automatically in CometAPIClient and used for any following invocations.
Add sample code for using TOTP based login.
Add utility for reading username, password and optionally TOTP.
Clean up code - Resolve - "receiver name should be a reflection of its identity; don't use generic names such as "this" or "self" (ST1006)" 
Remove deprecated ioutil calls.