### PR TITLE
Add support for custom headers like User-Agent and set default value for User-Agent

### DIFF
--- a/cometsdk.go
+++ b/cometsdk.go
@@ -20,6 +20,7 @@ const APPLICATION_VERSION string = "24.3.5"
 const APPLICATION_VERSION_MAJOR int = 24
 const APPLICATION_VERSION_MINOR int = 3
 const APPLICATION_VERSION_REVISION int = 5
+const USER_AGENT_HEADER string = "UserAgent"
 const DEFAULT_USER_AGENT string = "CometBackup/" + APPLICATION_VERSION
 
 // AutoRetentionLevel: The system will automatically choose how often to run an automatic Retention
@@ -4112,8 +4113,8 @@ type CometAPIClient struct {
 	// ReuseSessionKey is especially useful when using TOTP based authentication, otherwise
 	// you need to enter a new TOTPKey for every api call.
 	ReuseSessionKey bool
-	// User-Agent header value that will be set for the requests being made to the server.
-	UserAgent string
+	// Custom headers that will be set for the requests being made to the server.
+	CustomHeaders map[string]string
 }
 
 // NewCometAPIClient constructs and returns an instance of CometAPIClient
@@ -4124,10 +4125,10 @@ func NewCometAPIClient(serverURL, username, password string) (*CometAPIClient, e
 	}
 
 	return &CometAPIClient{
-		ServerURL: serverURL,
-		Username:  username,
-		Password:  password,
-		UserAgent: DEFAULT_USER_AGENT,
+		ServerURL:     serverURL,
+		Username:      username,
+		Password:      password,
+		CustomHeaders: map[string]string{USER_AGENT_HEADER: DEFAULT_USER_AGENT},
 	}, nil
 }
 
@@ -4144,8 +4145,10 @@ func (c *CometAPIClient) Request(contentType, method, path string, data map[stri
 	if err != nil {
 		return nil, err
 	}
-	if c.UserAgent != "" {
-		req.Header.Add("User-Agent", c.UserAgent)
+	if c.CustomHeaders != nil {
+		for header, value := range c.CustomHeaders {
+			req.Header.Add(header, value)
+		}
 	}
 
 	switch contentType {

--- a/cometsdk.go
+++ b/cometsdk.go
@@ -21,7 +21,7 @@ const APPLICATION_VERSION_MAJOR int = 24
 const APPLICATION_VERSION_MINOR int = 3
 const APPLICATION_VERSION_REVISION int = 8
 const USER_AGENT_HEADER string = "User-Agent"
-const DEFAULT_USER_AGENT string = "CometBackup/" + APPLICATION_VERSION
+const DEFAULT_USER_AGENT string = "comet-go-sdk/" + APPLICATION_VERSION
 
 // AutoRetentionLevel: The system will automatically choose how often to run an automatic Retention
 // Pass after each backup job.

--- a/cometsdk.go
+++ b/cometsdk.go
@@ -20,7 +20,7 @@ const APPLICATION_VERSION string = "24.3.8"
 const APPLICATION_VERSION_MAJOR int = 24
 const APPLICATION_VERSION_MINOR int = 3
 const APPLICATION_VERSION_REVISION int = 8
-const USER_AGENT_HEADER string = "UserAgent"
+const USER_AGENT_HEADER string = "User-Agent"
 const DEFAULT_USER_AGENT string = "CometBackup/" + APPLICATION_VERSION
 
 // AutoRetentionLevel: The system will automatically choose how often to run an automatic Retention

--- a/cometsdk.go
+++ b/cometsdk.go
@@ -20,6 +20,7 @@ const APPLICATION_VERSION string = "24.3.5"
 const APPLICATION_VERSION_MAJOR int = 24
 const APPLICATION_VERSION_MINOR int = 3
 const APPLICATION_VERSION_REVISION int = 5
+const DEFAULT_USER_AGENT string = "CometBackup/" + APPLICATION_VERSION
 
 // AutoRetentionLevel: The system will automatically choose how often to run an automatic Retention
 // Pass after each backup job.
@@ -4111,6 +4112,8 @@ type CometAPIClient struct {
 	// ReuseSessionKey is especially useful when using TOTP based authentication, otherwise
 	// you need to enter a new TOTPKey for every api call.
 	ReuseSessionKey bool
+	// User-Agent header value that will be set for the requests being made to the server.
+	UserAgent string
 }
 
 // NewCometAPIClient constructs and returns an instance of CometAPIClient
@@ -4124,6 +4127,7 @@ func NewCometAPIClient(serverURL, username, password string) (*CometAPIClient, e
 		ServerURL: serverURL,
 		Username:  username,
 		Password:  password,
+		UserAgent: DEFAULT_USER_AGENT,
 	}, nil
 }
 
@@ -4139,6 +4143,9 @@ func (c *CometAPIClient) Request(contentType, method, path string, data map[stri
 	req, err := http.NewRequest(strings.ToUpper(method), u.String(), nil)
 	if err != nil {
 		return nil, err
+	}
+	if c.UserAgent != "" {
+		req.Header.Add("User-Agent", c.UserAgent)
 	}
 
 	switch contentType {


### PR DESCRIPTION
It will be useful to set a default value for **User-Agent** for the sdk as it helps in bot detection support. 
Also, users of the sdk will be able set their own custom User-Agent for their needs. Open to suggestions or changes to the default value.

Setting the User-Agent header is a common practice when sending HTTP requests. 
It is useful for bot detection for a few reasons:

**Common Patterns:** While it's possible to set any value for the User-Agent, many bots and automated scripts use default or well-known User-Agent strings. By analyzing these patterns, web servers and security systems can identify and block requests that match known bot signatures.

**Good Bot Behavior:** Legitimate bots and crawlers often identify themselves with specific User-Agent strings to indicate their purpose and origin. For example, Googlebot identifies itself as "Googlebot". By allowing known bots and blocking unknown or suspicious ones, websites can ensure that legitimate web crawlers can access their content while blocking malicious or unwanted bots.

**Compliance and Standards:** While it's possible to spoof the User-Agent, many well-behaved bots and automated scripts follow standards and best practices, including providing accurate User-Agent information. Websites and services can use this information to enforce access policies and ensure compliance with their terms of service.

Adding application specific custom headers can provide even more security and customization.