### PR TITLE
Add TOTP and SessionKey support for multipart/form-data requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2024-08-01 v1.34.0
 
 - Based on Comet 24.6.10
-- Added TOTP and SessionKey support for multipart/form-data requests
+- Add TOTP and SessionKey support for multipart/form-data requests
 
 ## 2024-08-01 v1.33.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 2024-08-01 v1.34.0
+
+- Based on Comet 24.6.10
+- Added TOTP and SessionKey support for multipart/form-data requests
+
 ## 2024-08-01 v1.33.0
 
 - Based on Comet 24.6.6
@@ -107,7 +112,7 @@
 - Based on Comet 23.9.5
 - Add new field `LogLevel` to control job log verbosity
 - Add new `RESTORETYPE_WINDISK_ESXI` for restoring to VMware-compatible
-virtual disks
+  virtual disks
 
 ## 2023-09-19 v1.12.0
 
@@ -117,10 +122,10 @@ virtual disks
 - Added 'TOTPCode' to 'InstallCreds' used for device registration.
 - 'GroupedBy' added to 'PSAConfig' for grouping statistics.
 - New APIs
-	- AdminInstallationDispatchDropConnection
-	- AdminInstallationDispatchRegisterDevice
-	- AdminInstallationListActive
-	- AdminJobAbandon
+  - AdminInstallationDispatchDropConnection
+  - AdminInstallationDispatchRegisterDevice
+  - AdminInstallationListActive
+  - AdminJobAbandon
 
 ## 2023-08-29 v1.11.0
 
@@ -182,6 +187,7 @@ virtual disks
 - Support Azure Key Vault codesigning
 
 ## 2023-02-15 v1.3.0
+
 - Based on 22.12.8
 - Add `TimeSpan` option to `EmailReportOptions`
 - Add `AlertsDisabled` (default: false) toggle for `PSAConfig` objects
@@ -189,6 +195,7 @@ virtual disks
 - Improve documentation
 
 ## 2023-01-11 v1.2.0
+
 - Based on 22.12.2
 - Add new `AdminCountJobsForCustomSearchRequest` API to count total number of jobs for a given search query
 - Add new `AdminMetaEmailOptionsGetRequest` / `AdminMetaEmailOptionsSetRequest` / `AdminMetaSendTestReportRequest` APIs for managing tenant email settings
@@ -196,22 +203,27 @@ virtual disks
 - Add new tenant admin permission `AllowEditEmailOptions`
 
 # 2022-12-09 v1.1.0
+
 - Based on 22.11.1
 - New features for PSAs, remote URLs and MS SQL Server restores.
 - New features for exporting a self backup for single tenant.
 - Fix an issue with detecting errors in API responses.
 
 ## 2022-09-08 v1.0.1
+
 - Now based on Comet Server 22.9.0
 
 ## 2022-08-24 v1.0.0
+
 - Initial public release
 
 ## 2022-08-21 v0.0.2
+
 - Added UserWeb examples
 - Moved cometsdk to its own lib module
 - Added fix for some marshalling issues
 
 ## 2022-07-28 v0.0.1
+
 - Based on 22.6.8
 - Initial release

--- a/cometsdk.go
+++ b/cometsdk.go
@@ -4289,9 +4289,19 @@ func (c *CometAPIClient) Request(contentType, method, path string, data map[stri
 		req.Body = io.NopCloser(&body)
 
 		req.Header.Add("Content-Type", m.FormDataContentType())
-		req.Header.Add("X-Comet-Admin-AuthType", "Password")
 		req.Header.Add("X-Comet-Admin-Username", c.Username)
-		req.Header.Add("X-Comet-Admin-Password", c.Password)
+		if c.SessionKey != "" {
+			req.Header.Add("X-Comet-Admin-AuthType", "SessionKey")
+			req.Header.Add("X-Comet-Admin-SessionKey", c.SessionKey)
+		} else if c.TOTPKey != "" {
+			req.Header.Add("X-Comet-Admin-AuthType", "PasswordTOTP")
+			req.Header.Add("X-Comet-Admin-Password", c.Password)
+			req.Header.Add("X-Comet-Admin-TOTP", c.TOTPKey)
+			c.TOTPKey = "" // Once the TOTPKey is used, it is not usable again.
+		} else {
+			req.Header.Add("X-Comet-Admin-AuthType", "Password")
+			req.Header.Add("X-Comet-Admin-Password", c.Password)
+		}
 	default:
 		return nil, fmt.Errorf("Unexpected content type: %s", contentType)
 	}


### PR DESCRIPTION
TOTP and SessionKey support was previously added for application/x-www-form-urlencoded content type requests but missed for multipart/form-data requests. Added it for multipart as well now.