### PR TITLE
Fix Request method for multipart/form-data used in AdminMetaResourceNew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2024-08-23 v1.35.0
+
+- Based on Comet 24.6.10
+- Fix multipart/form-data requests used in AdminMetaResourceNew.
+- AdminMetaResourceNew now accepts a file path instead of the file contents.
+
 ## 2024-08-23 v1.34.0
 
 - Based on Comet 24.6.10


### PR DESCRIPTION
I wasn't able to get `AdminMetaResourceNew` to work with the Request method in its current form. I kept getting - "Error returned from API (code 500): Internal error".
Had to modify the Request method to use `m.CreateFormFile` and `http.NewRequest` when `"multipart/form-data"` is used as `contentType`.
As a result `AdminMetaResourceNew `now expects `"upload"` input to be a path to the file instead of the file content.

If there is another way to get AdminMetaResourceNew to work in the current form, we can close this PR.